### PR TITLE
Add extension methods to add URL fragments

### DIFF
--- a/src/UriBuilder.Fluent.UnitTests/ExtensionTests.cs
+++ b/src/UriBuilder.Fluent.UnitTests/ExtensionTests.cs
@@ -72,6 +72,22 @@ namespace FluentUriBuilder.Tests
         }
 
         [Fact]
+        public void TestAddFragmentArrayint()
+        {
+            var url = new UriBuilder("http://awesome.com")
+                    .WithFragment("awesome", new List<int>() { 1, 2 }.Cast<object>());
+            Assert.Equal("http://awesome.com/#awesome=1,2", url.Uri.ToString());
+        }
+
+        [Fact]
+        public void TestAddFragmentNoValue()
+        {
+            var url = new UriBuilder("http://awesome.com")
+                    .WithFragment("awesome");
+            Assert.Equal("http://awesome.com/#awesome", url.Uri.ToString());
+        }
+
+        [Fact]
         public void WithPort()
         {
             var url = new UriBuilder().WithPort(22);

--- a/src/UriBuilder.Fluent.UnitTests/ThrowsTests.cs
+++ b/src/UriBuilder.Fluent.UnitTests/ThrowsTests.cs
@@ -13,10 +13,12 @@ namespace FluentUriBuilder.Tests
         {
             var tstObj = new UriBuilder();
             Assert.Throws<ArgumentNullException>(() => tstObj.WithParameter(string.Empty, string.Empty));
+            Assert.Throws<ArgumentNullException>(() => tstObj.WithFragment(string.Empty, string.Empty));
             Assert.Throws<ArgumentNullException>(() => tstObj.WithPathSegment(null));
             Assert.Throws<ArgumentNullException>(() => tstObj.WithScheme(null));
             Assert.Throws<ArgumentNullException>(() => tstObj.WithHost(null));
             Assert.Throws<ArgumentNullException>(() => tstObj.WithParameter(parameterDictionary: null));
+            Assert.Throws<ArgumentNullException>(() => tstObj.WithFragment(fragmentDictionary: null));
             Assert.Throws<ArgumentOutOfRangeException>(() => tstObj.WithPort(-1));
         }
     }

--- a/src/UriBuilder.Fluent/TerribleDevUriExtensions.cs
+++ b/src/UriBuilder.Fluent/TerribleDevUriExtensions.cs
@@ -52,18 +52,7 @@ namespace System
                 valuesEnum = new string[0];
             }
             var intitialValue = string.IsNullOrWhiteSpace(bld.Query) ? "" : $"{bld.Query.TrimStart('?')}&";
-            var sb = new StringBuilder($"{intitialValue}{key}");
-            var validValueHit = false;
-            foreach(var value in valuesEnum)
-            {
-                var toSValue = value?.ToString();
-                if(string.IsNullOrWhiteSpace(toSValue)) continue;
-                // we can't just have an = sign since its valid to have query string paramters with no value;
-                if(!validValueHit) toSValue = "=" + value;
-                validValueHit = true;
-                sb.Append($"{toSValue},");
-            }
-            bld.Query = sb.ToString().TrimEnd(',');
+            bld.Query = intitialValue.AppendKeyValue(key, valuesEnum);
             return bld;
         }
 
@@ -111,18 +100,7 @@ namespace System
                 valuesEnum = new string[0];
             }
             var intitialValue = string.IsNullOrWhiteSpace(bld.Fragment) ? "" : $"{bld.Fragment.TrimStart('?')}&";
-            var sb = new StringBuilder($"{intitialValue}{key}");
-            var validValueHit = false;
-            foreach(var value in valuesEnum)
-            {
-                var toSValue = value?.ToString();
-                if(string.IsNullOrWhiteSpace(toSValue)) continue;
-                // we can't just have an = sign since its valid to have query string paramters with no value;
-                if(!validValueHit) toSValue = "=" + value;
-                validValueHit = true;
-                sb.Append($"{toSValue},");
-            }
-            bld.Fragment = sb.ToString().TrimEnd(',');
+            bld.Fragment = intitialValue.AppendKeyValue(key, valuesEnum);
             return bld;
         }
 
@@ -225,5 +203,23 @@ namespace System
         /// <returns></returns>
         public static string ToEscapeDataString(this UriBuilder bld) => Uri.EscapeDataString(bld.Uri.ToString());
 
+        /// <summary>
+        /// Appends x-www-form-urlencoded key and valuesEnum into initialValue.
+        /// </summary>
+        private static string AppendKeyValue(this string intitialValue, string key, IEnumerable<object> valuesEnum)
+        {
+            var sb = new StringBuilder($"{intitialValue}{key}");
+            var validValueHit = false;
+            foreach(var value in valuesEnum)
+            {
+                var toSValue = value?.ToString();
+                if(string.IsNullOrWhiteSpace(toSValue)) continue;
+                // we can't just have an = sign since its valid to have query string paramters with no value;
+                if(!validValueHit) toSValue = "=" + value;
+                validValueHit = true;
+                sb.Append($"{toSValue},");
+            }
+            return  sb.ToString().TrimEnd(',');
+        }
     }
 }

--- a/src/UriBuilder.Fluent/TerribleDevUriExtensions.cs
+++ b/src/UriBuilder.Fluent/TerribleDevUriExtensions.cs
@@ -68,6 +68,65 @@ namespace System
         }
 
         /// <summary>
+        /// Appends a fragments parameter with a key, and many values. Multiple values will be comma seperated. If only 1 value is passed and its null or value, the key will be added to the fragment.
+        /// </summary>
+        /// <param name="bld"></param>
+        /// <param name="key"></param>
+        /// <param name="values"></param>
+        /// <returns></returns>
+        public static UriBuilder WithFragment(this UriBuilder bld, string key, params string[] values) => bld.WithFragment(key, valuesEnum: values);
+
+        /// <summary>
+        /// Appends fragments from dictionary
+        /// </summary>
+        /// <param name="bld"></param>
+        /// <param name="fragmentDictionary"></param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <returns></returns>
+        public static UriBuilder WithFragment(this UriBuilder bld, IDictionary<string, string> fragmentDictionary)
+        {
+            if(fragmentDictionary == null) throw new ArgumentNullException(nameof(fragmentDictionary));
+            foreach(var item in fragmentDictionary)
+            {
+                bld.WithFragment(item.Key, item.Value);
+            }
+            return bld;
+        }
+
+        /// <summary>
+        /// Appends a fragments with a key, and many values. Multiple values will be comma seperated. If only 1 value is passed and its null or value, the key will be added to the fragment.
+        /// </summary>
+        /// <param name="bld"></param>
+        /// <param name="key"></param>
+        /// <param name="valuesEnum"></param>
+        /// <returns></returns>
+        public static UriBuilder WithFragment(this UriBuilder bld, string key, IEnumerable<object> valuesEnum)
+        {
+            if(string.IsNullOrWhiteSpace(key))
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+            if(valuesEnum == null)
+            {
+                valuesEnum = new string[0];
+            }
+            var intitialValue = string.IsNullOrWhiteSpace(bld.Fragment) ? "" : $"{bld.Fragment.TrimStart('?')}&";
+            var sb = new StringBuilder($"{intitialValue}{key}");
+            var validValueHit = false;
+            foreach(var value in valuesEnum)
+            {
+                var toSValue = value?.ToString();
+                if(string.IsNullOrWhiteSpace(toSValue)) continue;
+                // we can't just have an = sign since its valid to have query string paramters with no value;
+                if(!validValueHit) toSValue = "=" + value;
+                validValueHit = true;
+                sb.Append($"{toSValue},");
+            }
+            bld.Fragment = sb.ToString().TrimEnd(',');
+            return bld;
+        }
+
+        /// <summary>
         /// Sets the port to be the port number
         /// </summary>
         /// <param name="bld"></param>


### PR DESCRIPTION
Copied almost as-is from `WithFragment` overloads.

We can also refactor the main logic to build the query / fragment string into a shared method to make it DRY.