### PR TITLE
Add WithParametersFromObject() extension method

### DIFF
--- a/src/UriBuilder.Fluent.UnitTests/ExtensionTests.cs
+++ b/src/UriBuilder.Fluent.UnitTests/ExtensionTests.cs
@@ -35,7 +35,7 @@ namespace FluentUriBuilder.Tests
                     .WithParameter("awesome", "yodawg");
             Assert.Equal("http://awesome.com/?awesome=yodawg", url.Uri.ToString());
         }
-        
+
         [Fact]
         public void PathAndQuery()
         {
@@ -61,6 +61,19 @@ namespace FluentUriBuilder.Tests
             var url = new UriBuilder("http://awesome.com")
                     .WithParameter("awesome", new List<int>() { 1, 2 }.Cast<object>());
             Assert.Equal("http://awesome.com/?awesome=1,2", url.Uri.ToString());
+        }
+
+        [Fact]
+        public void TestAddUrlParametersFromObject()
+        {
+            var url = new UriBuilder("http://awesome.com")
+                    .WithParametersFromObject(
+                        new {
+                            awesome = "yodawg",
+                            mucharray = new string[] { "so cool", "wow" },
+                            manyienumerable = (IEnumerable<string>)(new List<string>() { "how dis work", "so interest" })
+                        });
+            Assert.Equal("http://awesome.com/?awesome=yodawg&mucharray=so%20cool,wow&manyienumerable=how%20dis%20work,so%20interest", url.Uri.ToString());
         }
 
         [Fact]

--- a/src/UriBuilder.Fluent.UnitTests/ExtensionTests.cs
+++ b/src/UriBuilder.Fluent.UnitTests/ExtensionTests.cs
@@ -73,7 +73,7 @@ namespace FluentUriBuilder.Tests
                             mucharray = new string[] { "so cool", "wow" },
                             manyienumerable = (IEnumerable<string>)(new List<string>() { "how dis work", "so interest" })
                         });
-            Assert.Equal("http://awesome.com/?awesome=yodawg&mucharray=so%20cool,wow&manyienumerable=how%20dis%20work,so%20interest", url.Uri.ToString());
+            Assert.Equal("http://awesome.com/?awesome=yodawg&mucharray=so cool,wow&manyienumerable=how dis work,so interest", url.Uri.ToString());
         }
 
         [Fact]

--- a/src/UriBuilder.Fluent.UnitTests/ExtensionTests.cs
+++ b/src/UriBuilder.Fluent.UnitTests/ExtensionTests.cs
@@ -71,7 +71,7 @@ namespace FluentUriBuilder.Tests
                         new {
                             awesome = "yodawg",
                             mucharray = new string[] { "so cool", "wow" },
-                            manyienumerable = (IEnumerable<string>)(new List<string>() { "how dis work", "so interest" })
+                            manyienumerable = new List<string>() { "how dis work", "so interest" }
                         });
             Assert.Equal("http://awesome.com/?awesome=yodawg&mucharray=so cool,wow&manyienumerable=how dis work,so interest", url.Uri.ToString());
         }

--- a/src/UriBuilder.Fluent/TerribleDevUriExtensions.cs
+++ b/src/UriBuilder.Fluent/TerribleDevUriExtensions.cs
@@ -56,11 +56,11 @@ namespace System
         /// <returns></returns>
         public static UriBuilder WithParameter(this UriBuilder bld, string key, IEnumerable<object> valuesEnum)
         {
-            if(string.IsNullOrWhiteSpace(key))
+            if (string.IsNullOrWhiteSpace(key))
             {
                 throw new ArgumentNullException(nameof(key));
             }
-            if(valuesEnum == null)
+            if (valuesEnum == null)
             {
                 valuesEnum = new string[0];
             }
@@ -114,8 +114,8 @@ namespace System
         /// <returns></returns>
         public static UriBuilder WithFragment(this UriBuilder bld, IDictionary<string, string> fragmentDictionary)
         {
-            if(fragmentDictionary == null) throw new ArgumentNullException(nameof(fragmentDictionary));
-            foreach(var item in fragmentDictionary)
+            if (fragmentDictionary == null) throw new ArgumentNullException(nameof(fragmentDictionary));
+            foreach (var item in fragmentDictionary)
             {
                 bld.WithFragment(item.Key, item.Value);
             }
@@ -131,11 +131,11 @@ namespace System
         /// <returns></returns>
         public static UriBuilder WithFragment(this UriBuilder bld, string key, IEnumerable<object> valuesEnum)
         {
-            if(string.IsNullOrWhiteSpace(key))
+            if (string.IsNullOrWhiteSpace(key))
             {
                 throw new ArgumentNullException(nameof(key));
             }
-            if(valuesEnum == null)
+            if (valuesEnum == null)
             {
                 valuesEnum = new string[0];
             }
@@ -153,7 +153,7 @@ namespace System
         /// <returns></returns>
         public static UriBuilder WithPort(this UriBuilder bld, int port)
         {
-            if(port < 1) throw new ArgumentOutOfRangeException(nameof(port));
+            if (port < 1) throw new ArgumentOutOfRangeException(nameof(port));
             bld.Port = port;
             return bld;
         }
@@ -178,7 +178,7 @@ namespace System
         /// <returns></returns>
         public static UriBuilder WithPathSegment(this UriBuilder bld, string pathSegment)
         {
-            if(string.IsNullOrWhiteSpace(pathSegment))
+            if (string.IsNullOrWhiteSpace(pathSegment))
             {
                 throw new ArgumentNullException(nameof(pathSegment));
             }
@@ -196,7 +196,7 @@ namespace System
         /// <returns></returns>
         public static UriBuilder WithScheme(this UriBuilder bld, string scheme)
         {
-            if(string.IsNullOrWhiteSpace(scheme)) throw new ArgumentNullException(nameof(scheme));
+            if (string.IsNullOrWhiteSpace(scheme)) throw new ArgumentNullException(nameof(scheme));
             bld.Scheme = scheme;
             return bld;
         }
@@ -210,7 +210,7 @@ namespace System
         /// <returns></returns>
         public static UriBuilder WithHost(this UriBuilder bld, string host)
         {
-            if(string.IsNullOrWhiteSpace(host)) throw new ArgumentNullException(nameof(host));
+            if (string.IsNullOrWhiteSpace(host)) throw new ArgumentNullException(nameof(host));
             bld.Host = host;
             return bld;
         }
@@ -250,16 +250,16 @@ namespace System
         {
             var sb = new StringBuilder($"{intitialValue}{key}");
             var validValueHit = false;
-            foreach(var value in valuesEnum)
+            foreach (var value in valuesEnum)
             {
                 var toSValue = value?.ToString();
-                if(string.IsNullOrWhiteSpace(toSValue)) continue;
+                if (string.IsNullOrWhiteSpace(toSValue)) continue;
                 // we can't just have an = sign since its valid to have query string paramters with no value;
-                if(!validValueHit) toSValue = "=" + value;
+                if (!validValueHit) toSValue = "=" + value;
                 validValueHit = true;
                 sb.Append($"{toSValue},");
             }
-            return  sb.ToString().TrimEnd(',');
+            return sb.ToString().TrimEnd(',');
         }
     }
 }

--- a/src/UriBuilder.Fluent/TerribleDevUriExtensions.cs
+++ b/src/UriBuilder.Fluent/TerribleDevUriExtensions.cs
@@ -26,8 +26,20 @@ namespace System
         /// <returns></returns>
         public static UriBuilder WithParameter(this UriBuilder bld, IDictionary<string, string> parameterDictionary)
         {
-            if(parameterDictionary == null) throw new ArgumentNullException(nameof(parameterDictionary));
-            foreach(var item in parameterDictionary)
+            return bld.WithParameter((IEnumerable <KeyValuePair<string, string>>)parameterDictionary);
+        }
+
+        /// <summary>
+        /// Appends query strings from an enumerable of key-value pairs
+        /// </summary>
+        /// <param name="bld"></param>
+        /// <param name="parameterEnumerable"></param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <returns></returns>
+        public static UriBuilder WithParameter(this UriBuilder bld, IEnumerable<KeyValuePair<string, string>> parameterEnumerable)
+        {
+            if (parameterEnumerable == null) throw new ArgumentNullException(nameof(parameterEnumerable));
+            foreach (var item in parameterEnumerable)
             {
                 bld.WithParameter(item.Key, item.Value);
             }

--- a/src/UriBuilder.Fluent/TerribleDevUriExtensions.cs
+++ b/src/UriBuilder.Fluent/TerribleDevUriExtensions.cs
@@ -89,7 +89,7 @@ namespace System
             // Each value is the ToString() of the property value
             //
             IEnumerable<KeyValuePair<string, string>> propertyValues = propertyInfo.Select(p =>
-                new KeyValuePair<string, string>(p.Name, p.GetValue(parameters, null).ToString()));
+                new KeyValuePair<string, string>(p.Name, p.GetValue(parameters, null)?.ToString()));
 
             // Return the UriBuilder with the parameters given by the kvp enumerable
             //

--- a/src/UriBuilder.Fluent/TerribleDevUriExtensions.cs
+++ b/src/UriBuilder.Fluent/TerribleDevUriExtensions.cs
@@ -28,20 +28,8 @@ namespace System
         /// <returns></returns>
         public static UriBuilder WithParameter(this UriBuilder bld, IDictionary<string, string> parameterDictionary)
         {
-            return bld.WithParameter((IEnumerable <KeyValuePair<string, string>>)parameterDictionary);
-        }
-
-        /// <summary>
-        /// Appends query strings from an enumerable of key-value pairs
-        /// </summary>
-        /// <param name="bld"></param>
-        /// <param name="parameterEnumerable"></param>
-        /// <exception cref="ArgumentNullException"></exception>
-        /// <returns></returns>
-        public static UriBuilder WithParameter(this UriBuilder bld, IEnumerable<KeyValuePair<string, string>> parameterEnumerable)
-        {
-            if (parameterEnumerable == null) throw new ArgumentNullException(nameof(parameterEnumerable));
-            foreach (var item in parameterEnumerable)
+            if (parameterDictionary == null) throw new ArgumentNullException(nameof(parameterDictionary));
+            foreach (var item in parameterDictionary)
             {
                 bld.WithParameter(item.Key, item.Value);
             }

--- a/src/UriBuilder.Fluent/TerribleDevUriExtensions.cs
+++ b/src/UriBuilder.Fluent/TerribleDevUriExtensions.cs
@@ -95,9 +95,9 @@ namespace System
 
                 IEnumerable<object> propertieValuesToAdd;
 
-                // Check if the property value type is an IEnumerable
+                // Check if the property value type is an IEnumerable, but not a string
                 //
-                if (propertyValueObject is IEnumerable enumerableValue)
+                if (!(propertyValueObject is string) && propertyValueObject is IEnumerable enumerableValue)
                 {
                     // We have an IEnumerable value
                     //


### PR DESCRIPTION
This PR adds a `WithParametersFromObject()` method.

The method takes an object, which may or may not be an anonymous type.

Each public, instanced property of the input object is converted into a call to `UriBuilder.WithParameter()`.

If the property is an `IEnumerable` (with the exception of `string`), the parameter is cast to `IEnumerable<object>` and passed into the existing `UriBuilder.WithParameter(string, IEnumerable<object>)` method.

If the property is any other object, it is added as the sole member of an `object[]` and passed into the same `UriBuilder.WithParameter(string, IEnumerable<object>)` method.

The PR also adds a test for this method.

Should close Issue https://github.com/TerribleDev/UriBuilder.Fluent/issues/1